### PR TITLE
Guard empty m_members in CSE_ALifeOnlineOfflineGroup

### DIFF
--- a/src/xrGame/alife_online_offline_group.cpp
+++ b/src/xrGame/alife_online_offline_group.cpp
@@ -56,7 +56,7 @@ CSE_ALifeDynamicObject* CSE_ALifeOnlineOfflineGroup::tpfGetBestDetector() { retu
 bool CSE_ALifeOnlineOfflineGroup::need_update(CSE_ALifeDynamicObject* object) { return true; }
 void CSE_ALifeOnlineOfflineGroup::update()
 {
-    if (m_bOnline)
+    if (m_bOnline && !m_members.empty())
     {
         MEMBER* commander = (*m_members.begin()).second;
         o_Position = commander->o_Position;
@@ -195,7 +195,7 @@ CSE_ALifeOnlineOfflineGroup::MEMBER* CSE_ALifeOnlineOfflineGroup::member(ALife::
 
 bool CSE_ALifeOnlineOfflineGroup::synchronize_location()
 {
-    if (m_bOnline)
+    if (m_bOnline && !m_members.empty())
     {
         MEMBER* member = (*m_members.begin()).second;
         o_Position = member->o_Position;


### PR DESCRIPTION
Port the empty-squad guard from X-Ray Monolith to prevent dereferencing "m_members.begin()" when an online squad has no members.

Added "!m_members.empty()" checks in:

"CSE_ALifeOnlineOfflineGroup::update()"
"CSE_ALifeOnlineOfflineGroup::synchronize_location()"

An online squad can temporarily have zero members after all members are unregistered, leaving "m_bOnline == true". Both functions previously dereferenced "m_members.begin()" without checking for an empty container.

This keeps the change limited to the affected code paths.
