### PR TITLE
Port moving-target pathing fix from Anomaly modded EXEs

### DIFF
--- a/src/xrGame/alife_monster_detail_path_manager.cpp
+++ b/src/xrGame/alife_monster_detail_path_manager.cpp
@@ -132,6 +132,7 @@ void CALifeMonsterDetailPathManager::update_position()
 void CALifeMonsterDetailPathManager::make_inactual() { m_path.clear(); }
 void CALifeMonsterDetailPathManager::actualize()
 {
+    
     GameGraph::_GRAPH_ID old_next_gv = GameGraph::_GRAPH_ID(-1);
     float old_walked = m_walked_distance;
 
@@ -147,9 +148,66 @@ void CALifeMonsterDetailPathManager::actualize()
         object().get_object().m_tGraphID,
         m_destination.m_game_vertex_id,
         &m_path,
-        temp
-    );
+        temp);
 
+#ifdef DEBUG
+    if (failed)
+    {
+        Msg("! %s couldn't build game path from", object().get_object().name_replace());
+        {
+            const CGameGraph::CGameVertex* vertex =
+                ai().game_graph().vertex(object().get_object().m_tGraphID);
+
+            Msg(
+                "! [%d][%s][%f][%f][%f]",
+                object().get_object().m_tGraphID,
+                ai().game_graph().header().level(vertex->level_id()).name().c_str(),
+                VPUSH(vertex->level_point()));
+
+            Msg(
+                "! game_graph_mask -> [ %d, %d, %d, %d]",
+                vertex->vertex_type()[0],
+                vertex->vertex_type()[1],
+                vertex->vertex_type()[2],
+                vertex->vertex_type()[3]);
+        }
+
+        {
+            const CGameGraph::CGameVertex* vertex =
+                ai().game_graph().vertex(m_destination.m_game_vertex_id);
+
+            Msg(
+                "! [%d][%s][%f][%f][%f]",
+                m_destination.m_game_vertex_id,
+                ai().game_graph().header().level(vertex->level_id()).name().c_str(),
+                VPUSH(vertex->level_point()));
+
+            Msg(
+                "! game_graph_mask -> [ %d, %d, %d, %d]",
+                vertex->vertex_type()[0],
+                vertex->vertex_type()[1],
+                vertex->vertex_type()[2],
+                vertex->vertex_type()[3]);
+        }
+
+        Msg("! List of available game_graph masks:");
+
+        xr_vector<GameGraph::STerrainPlace>::iterator I =
+            object().m_tpaTerrain.begin();
+        xr_vector<GameGraph::STerrainPlace>::iterator E =
+            object().m_tpaTerrain.end();
+
+        for (; I != E; ++I)
+        {
+            Msg(
+                "! [%d , %d , %d , %d]",
+                (*I).tMask[0],
+                (*I).tMask[1],
+                (*I).tMask[2],
+                (*I).tMask[3]);
+        };
+    }
+#endif
 
     if (failed)
         return;

--- a/src/xrGame/alife_monster_detail_path_manager.cpp
+++ b/src/xrGame/alife_monster_detail_path_manager.cpp
@@ -132,82 +132,24 @@ void CALifeMonsterDetailPathManager::update_position()
 void CALifeMonsterDetailPathManager::make_inactual() { m_path.clear(); }
 void CALifeMonsterDetailPathManager::actualize()
 {
-    
-    GameGraph::_GRAPH_ID old_next_gv = GameGraph::_GRAPH_ID(-1);
-    float old_walked = m_walked_distance;
-
-    if (m_path.size() > 1)
-        old_next_gv = (GameGraph::_GRAPH_ID)m_path[m_path.size() - 2];
-
     m_path.clear();
 
     typedef GraphEngineSpace::CGameVertexParams CGameVertexParams;
     CGameVertexParams temp = CGameVertexParams(object().m_tpaTerrain);
     bool failed = !ai().graph_engine().search(
-        ai().game_graph(),
-        object().get_object().m_tGraphID,
-        m_destination.m_game_vertex_id,
-        &m_path,
-        temp);
+        ai().game_graph(), object().get_object().m_tGraphID, m_destination.m_game_vertex_id, &m_path, temp);
 
 #ifdef DEBUG
     if (failed)
     {
         Msg("! %s couldn't build game path from", object().get_object().name_replace());
         {
-            const CGameGraph::CGameVertex* vertex =
-                ai().game_graph().vertex(object().get_object().m_tGraphID);
-
-            Msg(
-                "! [%d][%s][%f][%f][%f]",
-                object().get_object().m_tGraphID,
-                ai().game_graph().header().level(vertex->level_id()).name().c_str(),
-                VPUSH(vertex->level_point()));
-
-            Msg(
-                "! game_graph_mask -> [ %d, %d, %d, %d]",
-                vertex->vertex_type()[0],
-                vertex->vertex_type()[1],
-                vertex->vertex_type()[2],
-                vertex->vertex_type()[3]);
+            const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(object().get_object().m_tGraphID);
+            Msg("! [%d][%s][%f][%f][%f]", object().get_object().m_tGraphID,
+                ai().game_graph().header().level(vertex->level_id()).name().c_str(), VPUSH(vertex->level_point()));
+            Msg("! game_graph_mask -> [ %d, %d, %d, %d]", vertex->vertex_type()[0], vertex->vertex_type()[1],
+                vertex->vertex_type()[2], vertex->vertex_type()[3]);
         }
-
-        {
-            const CGameGraph::CGameVertex* vertex =
-                ai().game_graph().vertex(m_destination.m_game_vertex_id);
-
-            Msg(
-                "! [%d][%s][%f][%f][%f]",
-                m_destination.m_game_vertex_id,
-                ai().game_graph().header().level(vertex->level_id()).name().c_str(),
-                VPUSH(vertex->level_point()));
-
-            Msg(
-                "! game_graph_mask -> [ %d, %d, %d, %d]",
-                vertex->vertex_type()[0],
-                vertex->vertex_type()[1],
-                vertex->vertex_type()[2],
-                vertex->vertex_type()[3]);
-        }
-
-        Msg("! List of available game_graph masks:");
-
-        xr_vector<GameGraph::STerrainPlace>::iterator I =
-            object().m_tpaTerrain.begin();
-        xr_vector<GameGraph::STerrainPlace>::iterator E =
-            object().m_tpaTerrain.end();
-
-        for (; I != E; ++I)
-        {
-            Msg(
-                "! [%d , %d , %d , %d]",
-                (*I).tMask[0],
-                (*I).tMask[1],
-                (*I).tMask[2],
-                (*I).tMask[3]);
-        };
-    }
-#endif
 
         {
             const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(m_destination.m_game_vertex_id);

--- a/src/xrGame/alife_monster_detail_path_manager.cpp
+++ b/src/xrGame/alife_monster_detail_path_manager.cpp
@@ -132,25 +132,41 @@ void CALifeMonsterDetailPathManager::update_position()
 void CALifeMonsterDetailPathManager::make_inactual() { m_path.clear(); }
 void CALifeMonsterDetailPathManager::actualize()
 {
-    GameGraph::_GRAPH_ID old_next_gv = GameGraph::_GRAPH_ID(-1);
-    float old_walked = m_walked_distance;
-
-    if (m_path.size() > 1)
-        old_next_gv = (GameGraph::_GRAPH_ID)m_path[m_path.size() - 2];
-
     m_path.clear();
 
     typedef GraphEngineSpace::CGameVertexParams CGameVertexParams;
     CGameVertexParams temp = CGameVertexParams(object().m_tpaTerrain);
     bool failed = !ai().graph_engine().search(
-        ai().game_graph(),
-        object().get_object().m_tGraphID,
-        m_destination.m_game_vertex_id,
-        &m_path,
-        temp
-    );
+        ai().game_graph(), object().get_object().m_tGraphID, m_destination.m_game_vertex_id, &m_path, temp);
 
+#ifdef DEBUG
+    if (failed)
+    {
+        Msg("! %s couldn't build game path from", object().get_object().name_replace());
+        {
+            const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(object().get_object().m_tGraphID);
+            Msg("! [%d][%s][%f][%f][%f]", object().get_object().m_tGraphID,
+                ai().game_graph().header().level(vertex->level_id()).name().c_str(), VPUSH(vertex->level_point()));
+            Msg("! game_graph_mask -> [ %d, %d, %d, %d]", vertex->vertex_type()[0], vertex->vertex_type()[1],
+                vertex->vertex_type()[2], vertex->vertex_type()[3]);
+        }
 
+        {
+            const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(m_destination.m_game_vertex_id);
+            Msg("! [%d][%s][%f][%f][%f]", m_destination.m_game_vertex_id,
+                ai().game_graph().header().level(vertex->level_id()).name().c_str(), VPUSH(vertex->level_point()));
+            Msg("! game_graph_mask -> [ %d, %d, %d, %d]", vertex->vertex_type()[0], vertex->vertex_type()[1],
+                vertex->vertex_type()[2], vertex->vertex_type()[3]);
+        }
+        Msg("! List of available game_graph masks:");
+        xr_vector<GameGraph::STerrainPlace>::iterator I = object().m_tpaTerrain.begin();
+        xr_vector<GameGraph::STerrainPlace>::iterator E = object().m_tpaTerrain.end();
+        for (; I != E; ++I)
+        {
+            Msg("! [%d , %d , %d , %d]", (*I).tMask[0], (*I).tMask[1], (*I).tMask[2], (*I).tMask[3]);
+        };
+    }
+#endif
     if (failed)
         return;
 
@@ -162,18 +178,9 @@ void CALifeMonsterDetailPathManager::actualize()
         return;
     }
 
+    m_walked_distance = 0.f;
     std::reverse(m_path.begin(), m_path.end());
     VERIFY(m_path.back() == object().get_object().m_tGraphID);
-
-    if (m_path.size() > 1 &&
-        (GameGraph::_GRAPH_ID)m_path[m_path.size() - 2] == old_next_gv)
-    {
-        m_walked_distance = old_walked;
-    }
-    else
-    {
-        m_walked_distance = 0.f;
-    }
 }
 
 void CALifeMonsterDetailPathManager::update(const ALife::_TIME_ID& time_delta)

--- a/src/xrGame/alife_monster_detail_path_manager.cpp
+++ b/src/xrGame/alife_monster_detail_path_manager.cpp
@@ -132,7 +132,8 @@ void CALifeMonsterDetailPathManager::update_position()
 void CALifeMonsterDetailPathManager::make_inactual() { m_path.clear(); }
 void CALifeMonsterDetailPathManager::actualize()
 {
-    
+    // Preserve progress on the current game-graph edge when the target moves
+    // but the recalculated path still uses the same next vertex.
     GameGraph::_GRAPH_ID old_next_gv = GameGraph::_GRAPH_ID(-1);
     float old_walked = m_walked_distance;
 
@@ -143,6 +144,7 @@ void CALifeMonsterDetailPathManager::actualize()
 
     typedef GraphEngineSpace::CGameVertexParams CGameVertexParams;
     CGameVertexParams temp = CGameVertexParams(object().m_tpaTerrain);
+
     bool failed = !ai().graph_engine().search(
         ai().game_graph(),
         object().get_object().m_tGraphID,
@@ -154,6 +156,7 @@ void CALifeMonsterDetailPathManager::actualize()
     if (failed)
     {
         Msg("! %s couldn't build game path from", object().get_object().name_replace());
+
         {
             const CGameGraph::CGameVertex* vertex =
                 ai().game_graph().vertex(object().get_object().m_tGraphID);
@@ -209,36 +212,32 @@ void CALifeMonsterDetailPathManager::actualize()
     }
 #endif
 
-        {
-            const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(m_destination.m_game_vertex_id);
-            Msg("! [%d][%s][%f][%f][%f]", m_destination.m_game_vertex_id,
-                ai().game_graph().header().level(vertex->level_id()).name().c_str(), VPUSH(vertex->level_point()));
-            Msg("! game_graph_mask -> [ %d, %d, %d, %d]", vertex->vertex_type()[0], vertex->vertex_type()[1],
-                vertex->vertex_type()[2], vertex->vertex_type()[3]);
-        }
-        Msg("! List of available game_graph masks:");
-        xr_vector<GameGraph::STerrainPlace>::iterator I = object().m_tpaTerrain.begin();
-        xr_vector<GameGraph::STerrainPlace>::iterator E = object().m_tpaTerrain.end();
-        for (; I != E; ++I)
-        {
-            Msg("! [%d , %d , %d , %d]", (*I).tMask[0], (*I).tMask[1], (*I).tMask[2], (*I).tMask[3]);
-        };
-    }
-#endif
     if (failed)
         return;
 
     VERIFY(!m_path.empty());
 
+    // Already at destination.
     if (m_path.size() == 1)
     {
         VERIFY(m_path.back() == object().get_object().m_tGraphID);
+        m_walked_distance = 0.f;
         return;
     }
 
-    m_walked_distance = 0.f;
+    // search() produces the path in reverse order.
     std::reverse(m_path.begin(), m_path.end());
+
     VERIFY(m_path.back() == object().get_object().m_tGraphID);
+
+    // IMPORTANT:
+    // If the immediate next game-graph vertex did not change, retain the
+    // distance already travelled along that edge. This prevents a squad
+    // chasing a moving target from repeatedly restarting the same edge.
+    if ((GameGraph::_GRAPH_ID)m_path[m_path.size() - 2] == old_next_gv)
+        m_walked_distance = old_walked;
+    else
+        m_walked_distance = 0.f;
 }
 
 void CALifeMonsterDetailPathManager::update(const ALife::_TIME_ID& time_delta)

--- a/src/xrGame/alife_monster_detail_path_manager.cpp
+++ b/src/xrGame/alife_monster_detail_path_manager.cpp
@@ -132,41 +132,25 @@ void CALifeMonsterDetailPathManager::update_position()
 void CALifeMonsterDetailPathManager::make_inactual() { m_path.clear(); }
 void CALifeMonsterDetailPathManager::actualize()
 {
+    GameGraph::_GRAPH_ID old_next_gv = GameGraph::_GRAPH_ID(-1);
+    float old_walked = m_walked_distance;
+
+    if (m_path.size() > 1)
+        old_next_gv = (GameGraph::_GRAPH_ID)m_path[m_path.size() - 2];
+
     m_path.clear();
 
     typedef GraphEngineSpace::CGameVertexParams CGameVertexParams;
     CGameVertexParams temp = CGameVertexParams(object().m_tpaTerrain);
     bool failed = !ai().graph_engine().search(
-        ai().game_graph(), object().get_object().m_tGraphID, m_destination.m_game_vertex_id, &m_path, temp);
+        ai().game_graph(),
+        object().get_object().m_tGraphID,
+        m_destination.m_game_vertex_id,
+        &m_path,
+        temp
+    );
 
-#ifdef DEBUG
-    if (failed)
-    {
-        Msg("! %s couldn't build game path from", object().get_object().name_replace());
-        {
-            const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(object().get_object().m_tGraphID);
-            Msg("! [%d][%s][%f][%f][%f]", object().get_object().m_tGraphID,
-                ai().game_graph().header().level(vertex->level_id()).name().c_str(), VPUSH(vertex->level_point()));
-            Msg("! game_graph_mask -> [ %d, %d, %d, %d]", vertex->vertex_type()[0], vertex->vertex_type()[1],
-                vertex->vertex_type()[2], vertex->vertex_type()[3]);
-        }
 
-        {
-            const CGameGraph::CGameVertex* vertex = ai().game_graph().vertex(m_destination.m_game_vertex_id);
-            Msg("! [%d][%s][%f][%f][%f]", m_destination.m_game_vertex_id,
-                ai().game_graph().header().level(vertex->level_id()).name().c_str(), VPUSH(vertex->level_point()));
-            Msg("! game_graph_mask -> [ %d, %d, %d, %d]", vertex->vertex_type()[0], vertex->vertex_type()[1],
-                vertex->vertex_type()[2], vertex->vertex_type()[3]);
-        }
-        Msg("! List of available game_graph masks:");
-        xr_vector<GameGraph::STerrainPlace>::iterator I = object().m_tpaTerrain.begin();
-        xr_vector<GameGraph::STerrainPlace>::iterator E = object().m_tpaTerrain.end();
-        for (; I != E; ++I)
-        {
-            Msg("! [%d , %d , %d , %d]", (*I).tMask[0], (*I).tMask[1], (*I).tMask[2], (*I).tMask[3]);
-        };
-    }
-#endif
     if (failed)
         return;
 
@@ -178,9 +162,18 @@ void CALifeMonsterDetailPathManager::actualize()
         return;
     }
 
-    m_walked_distance = 0.f;
     std::reverse(m_path.begin(), m_path.end());
     VERIFY(m_path.back() == object().get_object().m_tGraphID);
+
+    if (m_path.size() > 1 &&
+        (GameGraph::_GRAPH_ID)m_path[m_path.size() - 2] == old_next_gv)
+    {
+        m_walked_distance = old_walked;
+    }
+    else
+    {
+        m_walked_distance = 0.f;
+    }
 }
 
 void CALifeMonsterDetailPathManager::update(const ALife::_TIME_ID& time_delta)


### PR DESCRIPTION
Added preservation of m_walked_distance when recalculating a path if the next game-graph vertex has not changed.
Previously, m_walked_distance was reset to 0.f after every path recalculation. With moving targets, frequent target updates could cause the squad to repeatedly lose its progress toward the target and mostly remain in place.
This keeps the change limited to CALifeMonsterDetailPathManager::actualize().